### PR TITLE
Alternative approach to adding focus to DOM

### DIFF
--- a/devtools/lightning-inspect.es5.js
+++ b/devtools/lightning-inspect.es5.js
@@ -762,22 +762,11 @@
           this.__renderOffscreen = v;
         }
       }
-    }); // defining the isfocused property and attribute
-
-    ElementCore.prototype._isfocused = false;
-    Object.defineProperty(ElementCore.prototype, 'isfocused', {
-      // We are working on the core!
-      get: function get() {
-        console.log('Inspector geeting is focused');
-        return this._isfocused;
-      },
-      set: function set(v) {
-        console.log('Inspector setting is focused');
-        this._isfocused = v; // Put the attribute 'isfocused' as the current value
-
-        val(this, 'isfocused', v, false);
-      }
     });
+
+    Element.prototype.updateDebugFocusState = function () {
+      val(this, 'hasfinalfocus', this.hasFinalFocus(), false);
+    };
 
     ElementCore.prototype.updateDebugTransforms = function () {
       var stage = this._element.stage;

--- a/devtools/lightning-inspect.js
+++ b/devtools/lightning-inspect.js
@@ -743,20 +743,9 @@ window.attachInspector = function({Element, ElementCore, Stage, Component, Eleme
         }
     });
 
-    // defining the isfocused property and attribute
-    ElementCore.prototype._isFocused = false;
-    Object.defineProperty(ElementCore.prototype, 'isfocused', {
-      // We are working on the core!
-      get: function() {
-        return this._isFocused
-      },
-      set: function(v) {
-        this._isFocused = v
-
-        // Put the attribute 'isfocused' as the current value
-        val(this, 'isfocused', v, false)
-      }
-    })
+    Element.prototype.updateDebugFocusState = function() {
+        val(this, 'hasfinalfocus', this.hasFinalFocus(), false);
+    }
 
     ElementCore.prototype.updateDebugTransforms = function() {
         const stage = this._element.stage

--- a/src/application/Application.mjs
+++ b/src/application/Application.mjs
@@ -103,10 +103,21 @@ export default class Application extends Component {
     }
 
     __updateFocus() {
+        const prevFocusedComponent = this._focusPath ? this._focusPath[this._focusPath.length - 1] : undefined;
         const notOverridden = this.__updateFocusRec();
 
         if (!Application.booting && notOverridden) {
             this.updateFocusSettings();
+        }
+
+        if (this.__options.debug) {
+            const newFocusedComponent = this._focusPath ? this._focusPath[this._focusPath.length - 1] : undefined;
+            prevFocusedComponent && prevFocusedComponent.updateDebugFocusState && prevFocusedComponent.updateDebugFocusState();
+            newFocusedComponent && newFocusedComponent.updateDebugFocusState && newFocusedComponent.updateDebugFocusState();
+
+            if (prevFocusedComponent !== newFocusedComponent) {
+                console.log('FOCUS ' + (newFocusedComponent && newFocusedComponent.getLocationString()));
+            }
         }
     }
 
@@ -140,12 +151,6 @@ export default class Application extends Component {
             }
 
             if (this._focusPath.length !== newFocusPath.length || index !== newFocusPath.length) {
-                // Set console focus
-                if (this.__options.debug) {
-                  console.log('FOCUS ' + newFocusedComponent.getLocationString());
-                  newFocusedComponent.isfocused = true
-                }
-
                 // Unfocus events.
                 for (let i = this._focusPath.length - 1; i >= index; i--) {
                     const unfocusedElement = this._focusPath.pop();
@@ -235,7 +240,7 @@ export default class Application extends Component {
             }
 
             current = nextFocus;
-        } while(true);
+        } while (true);
 
         return path;
     }

--- a/src/application/Application.mjs
+++ b/src/application/Application.mjs
@@ -102,8 +102,14 @@ export default class Application extends Component {
         this.__updateFocus();
     }
 
+    __focusedComponent() {
+        return this._focusPath ? this._focusPath[this._focusPath.length - 1] : undefined;
+    }
+
     __updateFocus() {
-        const prevFocusedComponent = this._focusPath ? this._focusPath[this._focusPath.length - 1] : undefined;
+        const prevFocusedComponent = this.__focusedComponent();
+
+        // The Application's focus path, therefore final focused component, may change here...
         const notOverridden = this.__updateFocusRec();
 
         if (!Application.booting && notOverridden) {
@@ -111,7 +117,9 @@ export default class Application extends Component {
         }
 
         if (this.__options.debug) {
-            const newFocusedComponent = this._focusPath ? this._focusPath[this._focusPath.length - 1] : undefined;
+            const newFocusedComponent = this.__focusedComponent();
+
+            // Testing for updateDebugFocusState safeties against lightning inspector not having been attached.
             prevFocusedComponent && prevFocusedComponent.updateDebugFocusState && prevFocusedComponent.updateDebugFocusState();
             newFocusedComponent && newFocusedComponent.updateDebugFocusState && newFocusedComponent.updateDebugFocusState();
 
@@ -127,7 +135,7 @@ export default class Application extends Component {
 
         const newFocusPath = this.__getFocusPath();
         const newFocusedComponent = newFocusPath[newFocusPath.length - 1];
-        const prevFocusedComponent = this._focusPath ? this._focusPath[this._focusPath.length - 1] : undefined;
+        const prevFocusedComponent = this.__focusedComponent();
 
         if (!prevFocusedComponent) {
             // Focus events.

--- a/src/tree/Element.mjs
+++ b/src/tree/Element.mjs
@@ -1596,19 +1596,6 @@ export default class Element {
         }
     }
 
-    /**
-     * isfocused property of the Elemenet
-     *
-     * This property sets and gets if the element has focus
-     */
-    get isfocused() {
-      return this.__core.isfocused;
-    }
-
-    set isfocused(v) {
-      this.__core.isfocused = Utils.isBoolean(v) ? v : false;
-    }
-
     get zIndex() {return this.__core.zIndex}
     set zIndex(v) {
         this.__core.zIndex = v;

--- a/src/tree/core/ElementCore.mjs
+++ b/src/tree/core/ElementCore.mjs
@@ -129,12 +129,6 @@ export default class ElementCore {
         this._isRoot = false;
 
         /**
-         * FOCUS!
-         */
-
-         this._isfocused = false;
-
-        /**
          * Iff true, during zSort, this element should be 're-sorted' because either:
          * - zIndex did chang
          * - zParent did change
@@ -165,19 +159,6 @@ export default class ElementCore {
         this.render = this._renderSimple;
 
         this._layout = null;
-    }
-
-    /**
-     * FOCUS SET/GET
-     *
-     * Focus property that tells if the item is focused or not
-     */
-    get isfocused() {
-      return this._isfocused
-    }
-
-    set isfocused(v) {
-      this._isfocused = Utils.isBoolean(v)
     }
 
     get offsetX() {


### PR DESCRIPTION
We need to remove focus from old items, as well as add it to new. We can go directly to the DOM, not via a property on the Component / Element, although there is a bit of a code smell in what I've done when we have to check for the existence `updateDebugFocusState` :-( .

Also, I've chosen 'hasfinalfocus' as the attribute name; this aligns with hasFocus and hasFinalFocus in our code, and avoids replicating (more or less) those.